### PR TITLE
feat: re-generate to include svg assets

### DIFF
--- a/generated/balancer.tokenlist.json
+++ b/generated/balancer.tokenlist.json
@@ -3,7 +3,7 @@
     "version": {
         "major": 1,
         "minor": 0,
-        "patch": 353
+        "patch": 354
     },
     "keywords": [
         "Balancer",
@@ -17,7 +17,7 @@
         "Swap"
     ],
     "logoURI": "https://raw.githubusercontent.com/balancer/pebbles/master/images/pebbles-pad.256w.png",
-    "timestamp": "2025-07-28T07:51:39.897Z",
+    "timestamp": "2025-08-05T03:34:37.901Z",
     "tokens": [
         {
             "chainId": 999,
@@ -643,287 +643,328 @@
             "address": "0xbdaB22CD9a4BcaB42Fe5Cf17e523A029cbe903Dc",
             "name": "Boeing Company Tokenized by Sailing",
             "symbol": "BAs",
-            "decimals": 18
+            "decimals": 18,
+            "logoURI": "https://raw.githubusercontent.com/burrbear-dev/tokenlists/main/src/assets/images/tokens/0xbdab22cd9a4bcab42fe5cf17e523a029cbe903dc.svg"
         },
         {
             "chainId": 80094,
             "address": "0x69B88c116cb7cBBC5B0f85CBeA1Be91DF40b56E1",
             "name": "Lockheed Martin Corporation Tokenized by Sailing",
             "symbol": "LMTs",
-            "decimals": 18
+            "decimals": 18,
+            "logoURI": "https://raw.githubusercontent.com/burrbear-dev/tokenlists/main/src/assets/images/tokens/0x69b88c116cb7cbbc5b0f85cbea1be91df40b56e1.svg"
         },
         {
             "chainId": 80094,
             "address": "0x24BC5c9a529024e2B670B5b8166993d4ECaefE22",
             "name": "Coinbase Global Inc Tokenized by Sailing",
             "symbol": "COINs",
-            "decimals": 18
+            "decimals": 18,
+            "logoURI": "https://raw.githubusercontent.com/burrbear-dev/tokenlists/main/src/assets/images/tokens/0x24bc5c9a529024e2b670b5b8166993d4ecaefe22.svg"
         },
         {
             "chainId": 80094,
             "address": "0x4E0c8b91183374D3aB5eE691b0F59F1a4A671D80",
             "name": "Warner Bros. Discovery Inc Tokenized by Sailing",
             "symbol": "WBDs",
-            "decimals": 18
+            "decimals": 18,
+            "logoURI": "https://raw.githubusercontent.com/burrbear-dev/tokenlists/main/src/assets/images/tokens/0x4e0c8b91183374d3ab5ee691b0f59f1a4a671d80.svg"
         },
         {
             "chainId": 80094,
             "address": "0xd9c5b692ed20fA4207f2da1a3db3450828d90a46",
             "name": "YieldMax Universe Fund of Option Income ETFs Tokenized by Sailing",
             "symbol": "YMAXs",
-            "decimals": 18
+            "decimals": 18,
+            "logoURI": "https://raw.githubusercontent.com/burrbear-dev/tokenlists/main/src/assets/images/tokens/0xd9c5b692ed20fa4207f2da1a3db3450828d90a46.svg"
         },
         {
             "chainId": 80094,
             "address": "0x25f838Dc9DFC8F4Ac5bF957c475F90860Dde3460",
             "name": "ARK Innovation ETF Tokenized By Sailing",
             "symbol": "ARKKs",
-            "decimals": 18
+            "decimals": 18,
+            "logoURI": "https://raw.githubusercontent.com/burrbear-dev/tokenlists/main/src/assets/images/tokens/0x25f838dc9dfc8f4ac5bf957c475f90860dde3460.svg"
         },
         {
             "chainId": 80094,
             "address": "0x17A238d9a31fFF2f1078C8e1E4b2aC6B84E3A068",
             "name": "Paramount Global Tokenized by Sailing",
             "symbol": "PARAs",
-            "decimals": 18
+            "decimals": 18,
+            "logoURI": "https://raw.githubusercontent.com/burrbear-dev/tokenlists/main/src/assets/images/tokens/0x17a238d9a31fff2f1078c8e1e4b2ac6b84e3a068.svg"
         },
         {
             "chainId": 80094,
             "address": "0x6379BB654aA1B63bC602DBC947f60305AB9d6467",
             "name": "YieldMax Short COIN Option Income Strategy ETF Tokenized by Sailing",
             "symbol": "FIATs",
-            "decimals": 18
+            "decimals": 18,
+            "logoURI": "https://raw.githubusercontent.com/burrbear-dev/tokenlists/main/src/assets/images/tokens/0x6379bb654aa1b63bc602dbc947f60305ab9d6467.svg"
         },
         {
             "chainId": 80094,
             "address": "0x39890d84ac4a0E94d486068486f6513470E541b4",
             "name": "Roundhill S&P 500 0DTE Covered Call Strategy ETF Tokenized by Sailing",
             "symbol": "XDTEs",
-            "decimals": 18
+            "decimals": 18,
+            "logoURI": "https://raw.githubusercontent.com/burrbear-dev/tokenlists/main/src/assets/images/tokens/0x39890d84ac4a0e94d486068486f6513470e541b4.svg"
         },
         {
             "chainId": 80094,
             "address": "0x77D5cbfE85b3DfB6dB3e63d9392829f4C34FFA86",
             "name": "Apple Inc Tokenized By Sailing",
             "symbol": "AAPLs",
-            "decimals": 18
+            "decimals": 18,
+            "logoURI": "https://raw.githubusercontent.com/burrbear-dev/tokenlists/main/src/assets/images/tokens/0x77d5cbfe85b3dfb6db3e63d9392829f4c34ffa86.svg"
         },
         {
             "chainId": 80094,
             "address": "0xca72Cf92768bc1ABEF4b14cFD3E096c8B5f54696",
             "name": "Tesla Inc Tokenized By Sailing",
             "symbol": "TSLAs",
-            "decimals": 18
+            "decimals": 18,
+            "logoURI": "https://raw.githubusercontent.com/burrbear-dev/tokenlists/main/src/assets/images/tokens/0xca72cf92768bc1abef4b14cfd3e096c8b5f54696.svg"
         },
         {
             "chainId": 80094,
             "address": "0x30F8a2fE5Ea2eb2E64b26CcbD33b690Ec4EFe723",
             "name": "Amazon.com Inc Tokenized By Sailing",
             "symbol": "AMZNs",
-            "decimals": 18
+            "decimals": 18,
+            "logoURI": "https://raw.githubusercontent.com/burrbear-dev/tokenlists/main/src/assets/images/tokens/0x30f8a2fe5ea2eb2e64b26ccbd33b690ec4efe723.svg"
         },
         {
             "chainId": 80094,
             "address": "0xa8e8EFB06Ff91e8c5BEeD849417945d39F3f22Eb",
             "name": "SPDR S&P 500 ETF Trust Tokenized By Sailing",
             "symbol": "SPYs",
-            "decimals": 18
+            "decimals": 18,
+            "logoURI": "https://raw.githubusercontent.com/burrbear-dev/tokenlists/main/src/assets/images/tokens/0xa8e8efb06ff91e8c5beed849417945d39f3f22eb.svg"
         },
         {
             "chainId": 80094,
             "address": "0x70fA06e485285B6873B0A93189B613E2d85dc5e2",
             "name": "GameStop Corp Tokenized By Sailing",
             "symbol": "GMEs",
-            "decimals": 18
+            "decimals": 18,
+            "logoURI": "https://raw.githubusercontent.com/burrbear-dev/tokenlists/main/src/assets/images/tokens/0x70fa06e485285b6873b0a93189b613e2d85dc5e2.svg"
         },
         {
             "chainId": 80094,
             "address": "0x59dEA303501B18c058882096b781B89B836aA12C",
             "name": "Grupo Supervielle SA Tokenized By Sailing",
             "symbol": "SUPVs",
-            "decimals": 18
+            "decimals": 18,
+            "logoURI": "https://raw.githubusercontent.com/burrbear-dev/tokenlists/main/src/assets/images/tokens/0x59dea303501b18c058882096b781b89b836aa12c.svg"
         },
         {
             "chainId": 80094,
             "address": "0xbc2CeE93341C0e10d2fd5ED502F17AF88CFa1E7B",
             "name": "YPF S.A. Tokenized by Sailing",
             "symbol": "YPFs",
-            "decimals": 18
+            "decimals": 18,
+            "logoURI": "https://raw.githubusercontent.com/burrbear-dev/tokenlists/main/src/assets/images/tokens/0xbc2cee93341c0e10d2fd5ed502f17af88cfa1e7b.svg"
         },
         {
             "chainId": 80094,
             "address": "0xf79d63c21d7C69f1097114716dDB76844169B363",
             "name": "YieldMax COIN Option Income Strategy ETF Tokenized by Sailing",
             "symbol": "CONYs",
-            "decimals": 18
+            "decimals": 18,
+            "logoURI": "https://raw.githubusercontent.com/burrbear-dev/tokenlists/main/src/assets/images/tokens/0xf79d63c21d7c69f1097114716ddb76844169b363.svg"
         },
         {
             "chainId": 80094,
             "address": "0xac894A14e3D2CE9E89AefD209b0a38c12AdcF624",
             "name": "MercadoLibre Inc. Tokenized by Sailing",
             "symbol": "MELIs",
-            "decimals": 18
+            "decimals": 18,
+            "logoURI": "https://raw.githubusercontent.com/burrbear-dev/tokenlists/main/src/assets/images/tokens/0xac894a14e3d2ce9e89aefd209b0a38c12adcf624.svg"
         },
         {
             "chainId": 80094,
             "address": "0x9933Bb212C36860EF22915D44b74a8Cf1ffd45BB",
             "name": "NVIDIA Corporation Tokenized by Sailing",
             "symbol": "NVDAs",
-            "decimals": 18
+            "decimals": 18,
+            "logoURI": "https://raw.githubusercontent.com/burrbear-dev/tokenlists/main/src/assets/images/tokens/0x9933bb212c36860ef22915d44b74a8cf1ffd45bb.svg"
         },
         {
             "chainId": 80094,
             "address": "0xB35ffDB091e2e4361d907d5AA7dB3C150846a3e1",
             "name": "Meta Platforms Inc Tokenized By Sailing",
             "symbol": "METAs",
-            "decimals": 18
+            "decimals": 18,
+            "logoURI": "https://raw.githubusercontent.com/burrbear-dev/tokenlists/main/src/assets/images/tokens/0xb35ffdb091e2e4361d907d5aa7db3c150846a3e1.svg"
         },
         {
             "chainId": 80094,
             "address": "0x849F0393632746AC5e8426b53d78266d1d8ac1cd",
             "name": "Circle Internet Group Inc Tokenized by Sailing",
             "symbol": "CRCLs",
-            "decimals": 18
+            "decimals": 18,
+            "logoURI": "https://raw.githubusercontent.com/burrbear-dev/tokenlists/main/src/assets/images/tokens/0x849f0393632746ac5e8426b53d78266d1d8ac1cd.svg"
         },
         {
             "chainId": 80094,
             "address": "0x8f7F14481a9c0943836898F825BFb5494b7828Db",
             "name": "DLocal Ltd Tokenized By Sailing",
             "symbol": "DLOs",
-            "decimals": 18
+            "decimals": 18,
+            "logoURI": "https://raw.githubusercontent.com/burrbear-dev/tokenlists/main/src/assets/images/tokens/0x8f7f14481a9c0943836898f825bfb5494b7828db.svg"
         },
         {
             "chainId": 80094,
             "address": "0x08bc8b0c234390a40Aa305277355fd1A1819f10E",
             "name": "Upstart Holdings Inc Tokenized by Sailing",
             "symbol": "UPSTs",
-            "decimals": 18
+            "decimals": 18,
+            "logoURI": "https://raw.githubusercontent.com/burrbear-dev/tokenlists/main/src/assets/images/tokens/0x08bc8b0c234390a40aa305277355fd1a1819f10e.svg"
         },
         {
             "chainId": 80094,
             "address": "0x7542d8347913fA8eE3090fFf38544CDF694dd5F9",
             "name": "NEOS S&P 500 High Income ETF Tokenized by Sailing",
             "symbol": "SPYIs",
-            "decimals": 18
+            "decimals": 18,
+            "logoURI": "https://raw.githubusercontent.com/burrbear-dev/tokenlists/main/src/assets/images/tokens/0x7542d8347913fa8ee3090fff38544cdf694dd5f9.svg"
         },
         {
             "chainId": 80094,
             "address": "0x3a33A4Fa4443A5fd4aa89349BB3D2bc1D644478b",
             "name": "AMC Entertainment Holdings Inc Tokenized By Sailing",
             "symbol": "AMCs",
-            "decimals": 18
+            "decimals": 18,
+            "logoURI": "https://raw.githubusercontent.com/burrbear-dev/tokenlists/main/src/assets/images/tokens/0x3a33a4fa4443a5fd4aa89349bb3d2bc1d644478b.svg"
         },
         {
             "chainId": 80094,
             "address": "0x12855A68877A95482CEA16a39AaA25009ac6E396",
             "name": "Invesco QQQ Trust Tokenized By Sailing",
             "symbol": "QQQs",
-            "decimals": 18
+            "decimals": 18,
+            "logoURI": "https://raw.githubusercontent.com/burrbear-dev/tokenlists/main/src/assets/images/tokens/0x12855a68877a95482cea16a39aaa25009ac6e396.svg"
         },
         {
             "chainId": 80094,
             "address": "0xB7ca08EEF00a58489A670a1E22D4c6D01579db2F",
             "name": "Microstrategy Inc Tokenized By Sailing",
             "symbol": "MSTRs",
-            "decimals": 18
+            "decimals": 18,
+            "logoURI": "https://raw.githubusercontent.com/burrbear-dev/tokenlists/main/src/assets/images/tokens/0xb7ca08eef00a58489a670a1e22d4c6d01579db2f.svg"
         },
         {
             "chainId": 80094,
             "address": "0xe9C99da8395C57Bd08830c547a9c5d57A23C5cB3",
             "name": "Ginkgo Bioworks Inc Tokenized By Sailing",
             "symbol": "DNAs",
-            "decimals": 18
+            "decimals": 18,
+            "logoURI": "https://raw.githubusercontent.com/burrbear-dev/tokenlists/main/src/assets/images/tokens/0xe9c99da8395c57bd08830c547a9c5d57a23c5cb3.svg"
         },
         {
             "chainId": 80094,
             "address": "0x8dcCB687201955299E7bb1da47664313ff6759dd",
             "name": "The Walt Disney Company Tokenized By Sailing",
             "symbol": "DISs",
-            "decimals": 18
+            "decimals": 18,
+            "logoURI": "https://raw.githubusercontent.com/burrbear-dev/tokenlists/main/src/assets/images/tokens/0x8dccb687201955299e7bb1da47664313ff6759dd.svg"
         },
         {
             "chainId": 80094,
             "address": "0x7195A0Bc1e8A8b29Cd426D545522d38e698120Bf",
             "name": "Goldman Sachs Physical Gold ETF Tokenized By Sailing",
             "symbol": "AAAUs",
-            "decimals": 18
+            "decimals": 18,
+            "logoURI": "https://raw.githubusercontent.com/burrbear-dev/tokenlists/main/src/assets/images/tokens/0x7195a0bc1e8a8b29cd426d545522d38e698120bf.svg"
         },
         {
             "chainId": 80094,
             "address": "0xD2A26cF1d3aB11799AFd3E2461eC7ea0D62eEC6C",
             "name": "Airbnb Inc Tokenized By Sailing",
             "symbol": "ABNBs",
-            "decimals": 18
+            "decimals": 18,
+            "logoURI": "https://raw.githubusercontent.com/burrbear-dev/tokenlists/main/src/assets/images/tokens/0xd2a26cf1d3ab11799afd3e2461ec7ea0d62eec6c.svg"
         },
         {
             "chainId": 80094,
             "address": "0x42BECBE61383ce454db886e2A2802eC88ddC6beb",
             "name": "Palantir Technologies Inc Tokenized by Sailing",
             "symbol": "PLTRs",
-            "decimals": 18
+            "decimals": 18,
+            "logoURI": "https://raw.githubusercontent.com/burrbear-dev/tokenlists/main/src/assets/images/tokens/0x42becbe61383ce454db886e2a2802ec88ddc6beb.svg"
         },
         {
             "chainId": 80094,
             "address": "0x4D9CeB1a0baA95b1Ae6198c152F44AB4e919824D",
             "name": "Dynatrace Inc Tokenized By Sailing",
             "symbol": "DTs",
-            "decimals": 18
+            "decimals": 18,
+            "logoURI": "https://raw.githubusercontent.com/burrbear-dev/tokenlists/main/src/assets/images/tokens/0x4d9ceb1a0baa95b1ae6198c152f44ab4e919824d.svg"
         },
         {
             "chainId": 80094,
             "address": "0x43456286034E248EFC1471687fA7e7fF6aC4Bd5a",
             "name": "McDonalds Tokenized By Sailing",
             "symbol": "MCDs",
-            "decimals": 18
+            "decimals": 18,
+            "logoURI": "https://raw.githubusercontent.com/burrbear-dev/tokenlists/main/src/assets/images/tokens/0x43456286034e248efc1471687fa7e7ff6ac4bd5a.svg"
         },
         {
             "chainId": 80094,
             "address": "0xB1fef1bcf006604c382200168932f00812Ac9FF0",
             "name": "The Goldman Sachs Group Inc Tokenized by Sailing",
             "symbol": "GSs",
-            "decimals": 18
+            "decimals": 18,
+            "logoURI": "https://raw.githubusercontent.com/burrbear-dev/tokenlists/main/src/assets/images/tokens/0xb1fef1bcf006604c382200168932f00812ac9ff0.svg"
         },
         {
             "chainId": 80094,
             "address": "0x6C353a03d1177b5bA0C4Da63dA77341433015F86",
             "name": "Uber Technologies Inc Tokenized by Sailing",
             "symbol": "UBERs",
-            "decimals": 18
+            "decimals": 18,
+            "logoURI": "https://raw.githubusercontent.com/burrbear-dev/tokenlists/main/src/assets/images/tokens/0x6c353a03d1177b5ba0c4da63da77341433015f86.svg"
         },
         {
             "chainId": 80094,
             "address": "0x682BedD46D9d308eF35eaa7F92430e8A57c73792",
             "name": "BlackRock Inc Tokenized by Sailing",
             "symbol": "BLKs",
-            "decimals": 18
+            "decimals": 18,
+            "logoURI": "https://raw.githubusercontent.com/burrbear-dev/tokenlists/main/src/assets/images/tokens/0x682bedd46d9d308ef35eaa7f92430e8a57c73792.svg"
         },
         {
             "chainId": 80094,
             "address": "0xB064c58a63EBf8D03CD7A063e9e5e1398CdeA138",
             "name": "BYD Company Limited Tokenized by Sailing",
             "symbol": "BYDs",
-            "decimals": 18
+            "decimals": 18,
+            "logoURI": "https://raw.githubusercontent.com/burrbear-dev/tokenlists/main/src/assets/images/tokens/0xb064c58a63ebf8d03cd7a063e9e5e1398cdea138.svg"
         },
         {
             "chainId": 80094,
             "address": "0x56b4930057bcF3Dc9b8f6F17FF64dD54698598e8",
             "name": "Microsoft Corporation Tokenized by Sailing",
             "symbol": "MSFTs",
-            "decimals": 18
+            "decimals": 18,
+            "logoURI": "https://raw.githubusercontent.com/burrbear-dev/tokenlists/main/src/assets/images/tokens/0x56b4930057bcf3dc9b8f6f17ff64dd54698598e8.svg"
         },
         {
             "chainId": 80094,
             "address": "0x23a9dfBc5f489311E891118a587C5367cc992a40",
             "name": "United States Natural Gas Fund LP Tokenized by Sailing",
             "symbol": "UNGs",
-            "decimals": 18
+            "decimals": 18,
+            "logoURI": "https://raw.githubusercontent.com/burrbear-dev/tokenlists/main/src/assets/images/tokens/0x23a9dfbc5f489311e891118a587c5367cc992a40.svg"
         },
         {
             "chainId": 80094,
             "address": "0x3e5D85dD846B4Ca5A12Eb19eBd21d2798b724c36",
             "name": "Sailing",
             "symbol": "SAIL",
-            "decimals": 18
+            "decimals": 18,
+            "logoURI": "https://raw.githubusercontent.com/burrbear-dev/tokenlists/main/src/assets/images/tokens/0x3e5d85dd846b4ca5a12eb19ebd21d2798b724c36.svg"
         }
     ]
 }


### PR DESCRIPTION
Updated the token list to include logoURI entries for sailing tokens with SVG icons.
